### PR TITLE
Remove type piracy

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "KLDivergences"
 uuid = "3c9cd921-3d3f-41e2-830c-e020174918cc"
 authors = ["Theo Galy-Fajou <theo.galyfajou@gmail.com> and contributors"]
-version = "0.1.3"
+version = "0.2.0"
 
 [deps]
 Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"

--- a/src/KLDivergences.jl
+++ b/src/KLDivergences.jl
@@ -19,11 +19,6 @@ Return the KL divergence of  KL(p||q), either by sampling or analytically
 """
 KL
 
-# This is type piracy... Bad! Bad! Bad!
-# See : https://github.com/JuliaStats/Distributions.jl/blob/master/src/functionals.jl#L32
-StatsBase.kldivergence(p::UnivariateDistribution, q::UnivariateDistribution) = KL(p, q)
-StatsBase.kldivergence(p::MultivariateDistribution, q::MultivariateDistribution) = KL(p, q)
-
 function KLbase(p, q, x)
     # We assume that p(x) > 0 since x is sampled from p
     logpdf(p, x) - logpdf(q, x)

--- a/src/KLDivergences.jl
+++ b/src/KLDivergences.jl
@@ -9,7 +9,7 @@ using SpecialFunctions
 using StatsBase: StatsBase, kldivergence
 
 
-export KL, kldivergence, symmetricKL
+export KL, symmetricKL
 
 """
     KL(p::Distribution, q::Distribution) -> T

--- a/test/multivariate.jl
+++ b/test/multivariate.jl
@@ -1,4 +1,4 @@
-@testset "univariate" begin
+@testset "multivariate" begin
     struct CholeskyMvNormal{TL,Tm} <: Distributions.AbstractMvNormal
         m::Tm
         L::TL

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,7 +14,6 @@ using Test
         p = Exponential(2.0)
         q = Exponential(5.0)
         @test symmetricKL(p, q) == symmetricKL(q, p)
-        @test kldivergence(p, q) == KL(p, q)
     end
 
 end


### PR DESCRIPTION
Following #12, remove the type piracy on StatsBase.kldivergence/Distributions types